### PR TITLE
Replace banana smoke test with ping/pong convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ commitlint check.
 
 See [docs/testing.md](docs/testing.md). At minimum:
 
-- `openclaw agent --agent main --message "say banana"` returns text
+- `openclaw agent --agent main --message "say pong"` returns `pong`
 - TUI multi-turn works
 - No zombie claude processes after messages
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,10 +37,10 @@ The installer is idempotent. Re-run after OpenClaw updates to re-apply patches.
 ```bash
 export GLUECLAW_KEY=local
 openclaw agent --agent main \
-  --message "say banana" 2>&1 | tail -n 1
+  --message "say pong" 2>&1 | tail -n 1
 ```
 
-Expected: `banana`
+Expected: `pong`
 
 ## Models
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -50,8 +50,8 @@ RUN_LIVE_TESTS=1 npm test          # everything (~32s)
 
 ```bash
 export GLUECLAW_KEY=local
-openclaw agent --agent main --message "say banana" 2>&1 | tail -n 1
-# Expected: banana
+openclaw agent --agent main --message "say pong" 2>&1 | tail -n 1
+# Expected: pong
 ```
 
 ### Multi-turn memory

--- a/src/__tests__/integration/mock-claude.mjs
+++ b/src/__tests__/integration/mock-claude.mjs
@@ -21,7 +21,7 @@ switch (scenario) {
     emit({
       type: "result",
       session_id: sessionId,
-      result: "banana",
+      result: "pong",
       usage: { input_tokens: 10, output_tokens: 5 },
     });
     break;
@@ -30,16 +30,16 @@ switch (scenario) {
     emit({ type: "system", subtype: "init", session_id: sessionId });
     emit({
       type: "stream_event",
-      event: { delta: { type: "text_delta", text: "ban" } },
+      event: { delta: { type: "text_delta", text: "po" } },
     });
     emit({
       type: "stream_event",
-      event: { delta: { type: "text_delta", text: "ana" } },
+      event: { delta: { type: "text_delta", text: "ng" } },
     });
     emit({
       type: "result",
       session_id: sessionId,
-      result: "banana",
+      result: "pong",
       usage: { input_tokens: 10, output_tokens: 5 },
     });
     break;

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -39,7 +39,7 @@ async function collectEvents(
     } as any;
 
     const messages = [
-      { role: "user" as const, content: opts?.prompt ?? "say banana" },
+      { role: "user" as const, content: opts?.prompt ?? "say pong" },
     ];
     const context = {
       systemPrompt: opts?.systemPrompt ?? "",
@@ -74,7 +74,7 @@ describe("createClaudeCliStreamFn integration", () => {
     const deltas = events.filter((e) => e.type === "text_delta");
     expect(deltas.length).toBeGreaterThanOrEqual(2);
     const deltaTexts = deltas.map((d) => d.delta as string);
-    expect(deltaTexts.join("")).toContain("banana");
+    expect(deltaTexts.join("")).toContain("pong");
   });
 
   it("assistant scenario: handles assistant message fallback", async () => {
@@ -196,7 +196,7 @@ async function launchStream(
   } as any;
   const context = {
     systemPrompt: "",
-    messages: [{ role: "user" as const, content: "say banana" }],
+    messages: [{ role: "user" as const, content: "say pong" }],
   } as any;
   const stream = await streamFn(model, context, {});
   const events: Array<{ type: string; [key: string]: unknown }> = [];


### PR DESCRIPTION
## Summary

- Replace "say banana" / "banana" with "say pong" / "pong" across all docs, mock CLI, and integration tests
- Standard ping/pong pattern is more conventional for smoke tests

No behavior change — purely cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)