### PR TITLE
Fix healthcheck CLI flags for claude subprocess

### DIFF
--- a/src/healthcheck.ts
+++ b/src/healthcheck.ts
@@ -52,11 +52,14 @@ export async function runHealthcheck(opts: {
     return new Promise((resolve) => {
       const env = { ...process.env, MOCK_SCENARIO: scenario };
       const args = [
-        "--system-prompt",
-        prompt,
+        "--dangerously-skip-permissions",
+        "-p",
         "--output-format",
         "stream-json",
-        "-p",
+        "--system-prompt",
+        prompt,
+        "--model",
+        "claude-sonnet-4-6",
         "say pong",
       ];
       const proc = spawn(claudeBin, args, {


### PR DESCRIPTION
## Summary

The healthcheck was missing `--dangerously-skip-permissions` and `--model` flags that glueclaw normally passes to the Claude CLI, causing the healthcheck to always fail on live servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)