### PR TITLE
Fix healthcheck: add --verbose flag required by claude CLI

### DIFF
--- a/src/healthcheck.ts
+++ b/src/healthcheck.ts
@@ -56,6 +56,7 @@ export async function runHealthcheck(opts: {
         "-p",
         "--output-format",
         "stream-json",
+        "--verbose",
         "--system-prompt",
         prompt,
         "--model",


### PR DESCRIPTION
## Summary

Claude CLI requires `--verbose` when using `--output-format=stream-json` with `-p`. Without it the CLI exits with an error, causing healthcheck to always report FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)