### PR TITLE
Emit tool activity events for TUI indicators

### DIFF
--- a/src/__tests__/integration/mock-claude.mjs
+++ b/src/__tests__/integration/mock-claude.mjs
@@ -129,6 +129,119 @@ switch (scenario) {
     process.exit(1);
     break;
 
+  case "tool-use":
+    emit({ type: "system", subtype: "init", session_id: sessionId });
+    emit({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_mock_001",
+            name: "Bash",
+            input: { command: "ls /tmp" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            tool_use_id: "toolu_mock_001",
+            type: "tool_result",
+            content: "file1\nfile2",
+            is_error: false,
+          },
+        ],
+      },
+    });
+    emit({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Found 2 files in /tmp." }],
+      },
+    });
+    emit({
+      type: "result",
+      session_id: sessionId,
+      result: "Found 2 files in /tmp.",
+      usage: { input_tokens: 20, output_tokens: 15 },
+    });
+    break;
+
+  case "multi-tool":
+    emit({ type: "system", subtype: "init", session_id: sessionId });
+    emit({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_mock_010",
+            name: "Read",
+            input: { file_path: "/tmp/a.txt" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            tool_use_id: "toolu_mock_010",
+            type: "tool_result",
+            content: "hello",
+            is_error: false,
+          },
+        ],
+      },
+    });
+    emit({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_mock_011",
+            name: "Bash",
+            input: { command: "echo world" },
+          },
+        ],
+      },
+    });
+    emit({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            tool_use_id: "toolu_mock_011",
+            type: "tool_result",
+            content: "world",
+            is_error: false,
+          },
+        ],
+      },
+    });
+    emit({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Done with both tools." }],
+      },
+    });
+    emit({
+      type: "result",
+      session_id: sessionId,
+      result: "Done with both tools.",
+      usage: { input_tokens: 30, output_tokens: 20 },
+    });
+    break;
+
   case "healthcheck": {
     // Simulate Anthropic detection: reject if system prompt contains HEALTHCHECK_REJECT_LINE
     const spIdx = process.argv.indexOf("--system-prompt");

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -176,6 +176,46 @@ describe("createClaudeCliStreamFn integration", () => {
   });
 });
 
+describe("tool activity indicators", () => {
+  it("tool-use scenario: emits toolcall_start and toolcall_end events", async () => {
+    const events = await collectEvents("tool-use");
+    const types = events.map((e) => e.type);
+    expect(types).toContain("toolcall_start");
+    expect(types).toContain("toolcall_end");
+  });
+
+  it("tool-use scenario: toolcall_start has tool name", async () => {
+    const events = await collectEvents("tool-use");
+    const start = events.find((e) => e.type === "toolcall_start");
+    expect(start).toBeDefined();
+    expect((start as any).toolName).toBe("Bash");
+  });
+
+  it("tool-use scenario: text after tool use is captured in done event", async () => {
+    const events = await collectEvents("tool-use");
+    const done = events.find((e) => e.type === "done");
+    expect(done).toBeDefined();
+    const msg = (done as any).message;
+    const text = msg?.content?.find((c: any) => c.type === "text")?.text;
+    expect(text).toContain("Found 2 files");
+  });
+
+  it("multi-tool scenario: emits multiple toolcall_start/end pairs", async () => {
+    const events = await collectEvents("multi-tool");
+    const starts = events.filter((e) => e.type === "toolcall_start");
+    const ends = events.filter((e) => e.type === "toolcall_end");
+    expect(starts.length).toBe(2);
+    expect(ends.length).toBe(2);
+  });
+
+  it("multi-tool scenario: tool names are correct", async () => {
+    const events = await collectEvents("multi-tool");
+    const starts = events.filter((e) => e.type === "toolcall_start");
+    expect((starts[0] as any).toolName).toBe("Read");
+    expect((starts[1] as any).toolName).toBe("Bash");
+  });
+});
+
 /**
  * Launch a stream and collect all events. Unlike collectEvents(), this does
  * NOT set process.env.MOCK_SCENARIO — the caller must set it once before

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -356,14 +356,46 @@ export function createClaudeCliStreamFn(opts: {
             continue;
           }
 
-          // Complete assistant message - only use if we didn't get streaming deltas
+          // Assistant message — may contain tool_use and/or text content blocks
           if (type === "assistant") {
-            if (!started) {
-              const content = data.message?.content;
-              if (content) {
+            const content = data.message?.content;
+            if (content) {
+              // Emit tool call events for any tool_use blocks
+              for (const block of content) {
+                if (block.type === "tool_use") {
+                  const b = block as {
+                    type: string;
+                    id: string;
+                    name: string;
+                    input: Record<string, unknown>;
+                  };
+                  startStream();
+                  const toolCall = {
+                    type: "toolCall" as const,
+                    id: b.id,
+                    name: b.name,
+                    arguments: (b.input ?? {}) as Record<string, any>,
+                  };
+                  stream.push({
+                    type: "toolcall_start",
+                    contentIndex: 0,
+                    toolName: b.name,
+                    partial: buildMsg(info, text, buildUsage()),
+                  } as any);
+                  stream.push({
+                    type: "toolcall_end",
+                    contentIndex: 0,
+                    toolCall,
+                    partial: buildMsg(info, text, buildUsage()),
+                  });
+                }
+              }
+
+              // Handle text blocks (only if we haven't streamed via deltas)
+              if (!streamed) {
                 const textBlocks = content
-                  .filter((b) => b.type === "text" && b.text)
-                  .map((b) => b.text ?? "");
+                  .filter((b: any) => b.type === "text" && b.text)
+                  .map((b: any) => b.text ?? "");
                 if (textBlocks.length > 0) {
                   const fullText = textBlocks.join("\n");
                   startStream();


### PR DESCRIPTION
## Summary

- Parse `tool_use` content blocks from Claude CLI NDJSON assistant messages
- Emit `toolcall_start` (with tool name) and `toolcall_end` (with full ToolCall object) to the OpenClaw event stream
- Handles single and multi-tool scenarios
- Text responses after tool execution are still captured correctly
- 5 new integration tests with `tool-use` and `multi-tool` mock scenarios

83 total tests, all passing.

Closes #6

## Test plan

- [x] 5 integration tests: single tool, multi-tool, tool names, text after tools
- [x] All 83 tests pass
- [x] Typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)