### PR TITLE
feat: allow overriding stream request timeout via GLUECLAW_REQUEST_TIMEOUT_MS

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The only way this breaks is if Anthropic changes how `--system-prompt` or `--out
 
 Switch in TUI: `/model glueclaw/glueclaw-opus`
 
+## Configuration
+
+| Env var                       | Default  | Description                                                                                                                                                                                                                                                                 |
+| ----------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GLUECLAW_REQUEST_TIMEOUT_MS` | `120000` | Maximum time (in milliseconds) to wait for the Claude CLI subprocess to complete a single request before it is terminated. Increase if long-running tool calls or extensive reasoning trip the default 120s limit. Invalid or non-positive values fall back to the default. |
+
+Example (10 minute timeout):
+
+```bash
+export GLUECLAW_REQUEST_TIMEOUT_MS=600000
+```
+
 ## Notes
 
 - Tested with Telegram and OpenClaw TUI

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,17 @@ const MODEL_MAP: Readonly<Record<string, string>> = {
   "glueclaw-haiku": "claude-haiku-4-5",
 };
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
+function resolveRequestTimeoutMs(): number {
+  const raw = process.env.GLUECLAW_REQUEST_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_REQUEST_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    return DEFAULT_REQUEST_TIMEOUT_MS;
+  return parsed;
+}
+
 export default definePluginEntry({
   register(api: OpenClawPluginApi): void {
     const authProfile = () =>
@@ -74,6 +85,7 @@ export default definePluginEntry({
         return createClaudeCliStreamFn({
           sessionKey: ctx.agentDir ?? "default",
           modelOverride: realModel,
+          requestTimeoutMs: resolveRequestTimeoutMs(),
         });
       },
       resolveSyntheticAuth: () => ({


### PR DESCRIPTION
Closes #22.

## Summary

Adds support for a `GLUECLAW_REQUEST_TIMEOUT_MS` environment variable that overrides the default 120s per-request timeout used when spawning the Claude CLI subprocess. Useful for long-running tool calls or extensive reasoning that would otherwise exceed 120s.

Default behaviour is unchanged: when the variable is unset, empty, or not a positive finite number, the existing 120s default is used.

## Changes

- `index.ts`: read `GLUECLAW_REQUEST_TIMEOUT_MS`, pass it as `requestTimeoutMs` to `createClaudeCliStreamFn`. Falls back to 120s on any invalid input.
- `README.md`: documents the new variable.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:unit` (51 tests) passes
- [x] `npm run test:integration` (25 tests) passes
- [ ] e2e tests not run locally (require live Claude CLI)