### PR TITLE
fix: pass real agent id to MCP gateway instead of hardcoded "main"

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import {
   definePluginEntry,
   type OpenClawPluginApi,
@@ -71,8 +72,10 @@ export default definePluginEntry({
       },
       createStreamFn: (ctx: { modelId: string; agentDir?: string }) => {
         const realModel = MODEL_MAP[ctx.modelId] ?? ctx.modelId;
+        const agentId = ctx.agentDir ? basename(ctx.agentDir) : undefined;
         return createClaudeCliStreamFn({
           sessionKey: ctx.agentDir ?? "default",
+          agentId,
           modelOverride: realModel,
         });
       },

--- a/src/__tests__/integration/mock-claude.mjs
+++ b/src/__tests__/integration/mock-claude.mjs
@@ -116,6 +116,20 @@ switch (scenario) {
     });
     break;
 
+  case "env-echo":
+    emit({ type: "system", subtype: "init", session_id: sessionId });
+    emit({
+      type: "result",
+      session_id: sessionId,
+      result: JSON.stringify({
+        OPENCLAW_MCP_AGENT_ID: process.env.OPENCLAW_MCP_AGENT_ID ?? null,
+        OPENCLAW_MCP_SESSION_KEY: process.env.OPENCLAW_MCP_SESSION_KEY ?? null,
+        OPENCLAW_MCP_TOKEN: process.env.OPENCLAW_MCP_TOKEN ?? null,
+      }),
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    break;
+
   case "hang":
     // Emit init then hang forever — never emits result
     emit({ type: "system", subtype: "init", session_id: sessionId });

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -336,3 +336,79 @@ describe("concurrency", () => {
     }
   });
 });
+
+/**
+ * Run a stream against the env-echo scenario and return the parsed env snapshot
+ * the subprocess saw. Requires MCP loopback env vars to be set on process.env
+ * so stream.ts wires up OPENCLAW_MCP_AGENT_ID/SESSION_KEY/TOKEN at all.
+ */
+async function captureSubprocessEnv(opts: {
+  agentId?: string;
+  sessionKey?: string;
+}): Promise<Record<string, string | null>> {
+  const origScenario = process.env.MOCK_SCENARIO;
+  const origPort = process.env.__GLUECLAW_MCP_PORT;
+  const origToken = process.env.__GLUECLAW_MCP_TOKEN;
+  process.env.MOCK_SCENARIO = "env-echo";
+  process.env.__GLUECLAW_MCP_PORT = "12345";
+  process.env.__GLUECLAW_MCP_TOKEN = "test-token";
+
+  try {
+    const streamFn = createClaudeCliStreamFn({
+      claudeBin: MOCK_CLI,
+      sessionKey: opts.sessionKey ?? `env-${Date.now()}-${Math.random()}`,
+      agentId: opts.agentId,
+      modelOverride: "claude-sonnet-4-6",
+    });
+    const model = {
+      id: "glueclaw-sonnet",
+      api: "anthropic-messages",
+      provider: "glueclaw",
+    } as any;
+    const context = {
+      systemPrompt: "",
+      messages: [{ role: "user" as const, content: "say pong" }],
+    } as any;
+    const stream = await streamFn(model, context, {});
+    let resultText = "";
+    for await (const event of stream) {
+      if ((event as any).type === "done") {
+        resultText = (event as any).message.content[0].text;
+      }
+    }
+    return JSON.parse(resultText);
+  } finally {
+    if (origScenario !== undefined) process.env.MOCK_SCENARIO = origScenario;
+    else delete process.env.MOCK_SCENARIO;
+    if (origPort !== undefined) process.env.__GLUECLAW_MCP_PORT = origPort;
+    else delete process.env.__GLUECLAW_MCP_PORT;
+    if (origToken !== undefined) process.env.__GLUECLAW_MCP_TOKEN = origToken;
+    else delete process.env.__GLUECLAW_MCP_TOKEN;
+  }
+}
+
+describe("MCP agent identity", () => {
+  it("propagates opts.agentId to OPENCLAW_MCP_AGENT_ID", async () => {
+    const env = await captureSubprocessEnv({ agentId: "evacastro" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+  });
+
+  it("uses a different agentId for a different agent", async () => {
+    const env = await captureSubprocessEnv({ agentId: "roy" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("roy");
+  });
+
+  it("falls back to 'main' when opts.agentId is omitted", async () => {
+    const env = await captureSubprocessEnv({});
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("main");
+  });
+
+  it("propagates opts.sessionKey alongside agentId independently", async () => {
+    const env = await captureSubprocessEnv({
+      agentId: "evacastro",
+      sessionKey: "session-xyz",
+    });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+    expect(env.OPENCLAW_MCP_SESSION_KEY).toBe("session-xyz");
+  });
+});

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -170,6 +170,7 @@ function evictSessions(): void {
 export function createClaudeCliStreamFn(opts: {
   claudeBin?: string;
   sessionKey?: string;
+  agentId?: string;
   modelOverride?: string;
   requestTimeoutMs?: number;
 }): StreamFn {
@@ -233,7 +234,7 @@ export function createClaudeCliStreamFn(opts: {
           args.push("--strict-mcp-config", "--mcp-config", mcp.path);
           env.OPENCLAW_MCP_TOKEN = loopback.token;
           env.OPENCLAW_MCP_SESSION_KEY = opts.sessionKey ?? "";
-          env.OPENCLAW_MCP_AGENT_ID = "main";
+          env.OPENCLAW_MCP_AGENT_ID = opts.agentId ?? "main";
           env.OPENCLAW_MCP_ACCOUNT_ID = "";
           env.OPENCLAW_MCP_MESSAGE_CHANNEL = "";
         }


### PR DESCRIPTION
Fixes #24.

## Summary
- `OPENCLAW_MCP_AGENT_ID` (forwarded as `x-openclaw-agent-id` to the gateway's MCP loopback) was hardcoded to `"main"`, so every non-default agent identified itself as `main` to the gateway. Any tool call that depends on agent identity (memory reads, session lookups, contextual routing) was operating against the wrong agent.
- Derive the agent id from `ctx.agentDir` basename in the plugin entry and thread it through `createClaudeCliStreamFn` opts (mirroring `sessionKey`).
- Falls back to `"main"` when no `agentDir` is provided so existing tests and minimal-context callers keep working.

## Changes
- `src/stream.ts`: add `agentId?: string` to `createClaudeCliStreamFn` opts; use `opts.agentId ?? "main"` for `OPENCLAW_MCP_AGENT_ID`.
- `index.ts`: derive `agentId = basename(ctx.agentDir)` and pass it through.
- `src/__tests__/integration/mock-claude.mjs`: add `env-echo` scenario emitting the relevant `OPENCLAW_MCP_*` env vars the subprocess sees.
- `src/__tests__/integration/stream.test.ts`: add `MCP agent identity` describe block — 4 cases covering explicit agent id, distinct agents, fallback, and independence from `sessionKey`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (80 passed / 7 skipped — 4 new tests)
- [ ] Manual: configure two distinct non-default agents and verify the gateway receives the correct `x-openclaw-agent-id` for each.

## Out of scope
`OPENCLAW_MCP_ACCOUNT_ID` and `OPENCLAW_MCP_MESSAGE_CHANNEL` are still empty strings — likely related but the runtime doesn't expose `accountId`/`messageChannel` to `createStreamFn`. Tracking separately.
