### PR TITLE
fix: re-inject system prompt on every CLI invocation, including --resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The only way this breaks is if Anthropic changes how `--system-prompt` or `--out
 
 Switch in TUI: `/model glueclaw/glueclaw-opus`
 
+## Configuration
+
+| Env var                       | Default  | Description                                                                                                                                                                                                                                                                 |
+| ----------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GLUECLAW_REQUEST_TIMEOUT_MS` | `120000` | Maximum time (in milliseconds) to wait for the Claude CLI subprocess to complete a single request before it is terminated. Increase if long-running tool calls or extensive reasoning trip the default 120s limit. Invalid or non-positive values fall back to the default. |
+
+Example (10 minute timeout):
+
+```bash
+export GLUECLAW_REQUEST_TIMEOUT_MS=600000
+```
+
 ## Notes
 
 - Tested with Telegram and OpenClaw TUI

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,17 @@ const MODEL_MAP: Readonly<Record<string, string>> = {
   "glueclaw-haiku": "claude-haiku-4-5",
 };
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
+function resolveRequestTimeoutMs(): number {
+  const raw = process.env.GLUECLAW_REQUEST_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_REQUEST_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    return DEFAULT_REQUEST_TIMEOUT_MS;
+  return parsed;
+}
+
 export default definePluginEntry({
   register(api: OpenClawPluginApi): void {
     const authProfile = () =>
@@ -77,6 +88,7 @@ export default definePluginEntry({
           sessionKey: ctx.agentDir ?? "default",
           agentId,
           modelOverride: realModel,
+          requestTimeoutMs: resolveRequestTimeoutMs(),
         });
       },
       resolveSyntheticAuth: () => ({

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import {
   definePluginEntry,
   type OpenClawPluginApi,
@@ -71,8 +72,10 @@ export default definePluginEntry({
       },
       createStreamFn: (ctx: { modelId: string; agentDir?: string }) => {
         const realModel = MODEL_MAP[ctx.modelId] ?? ctx.modelId;
+        const agentId = ctx.agentDir ? basename(ctx.agentDir) : undefined;
         return createClaudeCliStreamFn({
           sessionKey: ctx.agentDir ?? "default",
+          agentId,
           modelOverride: realModel,
         });
       },

--- a/src/__tests__/integration/mock-claude.mjs
+++ b/src/__tests__/integration/mock-claude.mjs
@@ -116,6 +116,20 @@ switch (scenario) {
     });
     break;
 
+  case "env-echo":
+    emit({ type: "system", subtype: "init", session_id: sessionId });
+    emit({
+      type: "result",
+      session_id: sessionId,
+      result: JSON.stringify({
+        OPENCLAW_MCP_AGENT_ID: process.env.OPENCLAW_MCP_AGENT_ID ?? null,
+        OPENCLAW_MCP_SESSION_KEY: process.env.OPENCLAW_MCP_SESSION_KEY ?? null,
+        OPENCLAW_MCP_TOKEN: process.env.OPENCLAW_MCP_TOKEN ?? null,
+      }),
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    break;
+
   case "hang":
     // Emit init then hang forever — never emits result
     emit({ type: "system", subtype: "init", session_id: sessionId });

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -412,3 +412,117 @@ describe("MCP agent identity", () => {
     expect(env.OPENCLAW_MCP_SESSION_KEY).toBe("session-xyz");
   });
 });
+
+/**
+ * Capture the args the Claude CLI subprocess was invoked with. Uses the
+ * args-echo mock scenario which emits the argv slice as the result text.
+ */
+async function captureSubprocessArgs(opts: {
+  sessionKey: string;
+  systemPrompt: string;
+  mockSessionId?: string;
+}): Promise<string[]> {
+  const origScenario = process.env.MOCK_SCENARIO;
+  const origMockSession = process.env.MOCK_SESSION_ID;
+  process.env.MOCK_SCENARIO = "args-echo";
+  if (opts.mockSessionId !== undefined)
+    process.env.MOCK_SESSION_ID = opts.mockSessionId;
+
+  try {
+    const streamFn = createClaudeCliStreamFn({
+      claudeBin: MOCK_CLI,
+      sessionKey: opts.sessionKey,
+      modelOverride: "claude-sonnet-4-6",
+    });
+    const model = {
+      id: "glueclaw-sonnet",
+      api: "anthropic-messages",
+      provider: "glueclaw",
+    } as any;
+    const context = {
+      systemPrompt: opts.systemPrompt,
+      messages: [{ role: "user" as const, content: "hi" }],
+    } as any;
+    const stream = await streamFn(model, context, {});
+    let resultText = "";
+    for await (const event of stream) {
+      if ((event as any).type === "done") {
+        resultText = (event as any).message.content[0].text;
+      }
+    }
+    return JSON.parse(resultText);
+  } finally {
+    if (origScenario !== undefined) process.env.MOCK_SCENARIO = origScenario;
+    else delete process.env.MOCK_SCENARIO;
+    if (origMockSession !== undefined)
+      process.env.MOCK_SESSION_ID = origMockSession;
+    else delete process.env.MOCK_SESSION_ID;
+  }
+}
+
+describe("system prompt re-injection on resume", () => {
+  it("includes --system-prompt on the first (fresh) call", async () => {
+    const args = await captureSubprocessArgs({
+      sessionKey: `sp-fresh-${Date.now()}-${Math.random()}`,
+      systemPrompt: "You are persona ALPHA.",
+    });
+    expect(args).toContain("--system-prompt");
+    const idx = args.indexOf("--system-prompt");
+    expect(args[idx + 1]).toBe("You are persona ALPHA.");
+    expect(args).not.toContain("--resume");
+  });
+
+  it("includes BOTH --resume and --system-prompt on subsequent calls", async () => {
+    const sessionKey = `sp-resume-${Date.now()}-${Math.random()}`;
+    const mockSessionId = `mock-sid-${Date.now()}`;
+
+    // First call populates sessionMap via the mock's system/init event.
+    await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are persona BETA.",
+      mockSessionId,
+    });
+
+    // Second call should resume AND re-inject the system prompt.
+    const args = await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are persona BETA.",
+      mockSessionId,
+    });
+    expect(args).toContain("--resume");
+    const resumeIdx = args.indexOf("--resume");
+    expect(args[resumeIdx + 1]).toBe(mockSessionId);
+    expect(args).toContain("--system-prompt");
+    const spIdx = args.indexOf("--system-prompt");
+    expect(args[spIdx + 1]).toBe("You are persona BETA.");
+  });
+
+  it("re-injects an updated system prompt on resume (identity drift recovery)", async () => {
+    const sessionKey = `sp-drift-${Date.now()}-${Math.random()}`;
+    const mockSessionId = `mock-sid-drift-${Date.now()}`;
+
+    await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are agent A (original).",
+      mockSessionId,
+    });
+
+    const args = await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are agent A (corrected).",
+      mockSessionId,
+    });
+    expect(args).toContain("--resume");
+    const spIdx = args.indexOf("--system-prompt");
+    expect(spIdx).toBeGreaterThanOrEqual(0);
+    expect(args[spIdx + 1]).toBe("You are agent A (corrected).");
+  });
+
+  it("omits --system-prompt entirely when no system prompt is provided", async () => {
+    const args = await captureSubprocessArgs({
+      sessionKey: `sp-empty-${Date.now()}-${Math.random()}`,
+      systemPrompt: "",
+    });
+    expect(args).not.toContain("--system-prompt");
+  });
+});

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -336,3 +336,79 @@ describe("concurrency", () => {
     }
   });
 });
+
+/**
+ * Run a stream against the env-echo scenario and return the parsed env snapshot
+ * the subprocess saw. Requires MCP loopback env vars to be set on process.env
+ * so stream.ts wires up OPENCLAW_MCP_AGENT_ID/SESSION_KEY/TOKEN at all.
+ */
+async function captureSubprocessEnv(opts: {
+  agentId?: string;
+  sessionKey?: string;
+}): Promise<Record<string, string | null>> {
+  const origScenario = process.env.MOCK_SCENARIO;
+  const origPort = process.env.__GLUECLAW_MCP_PORT;
+  const origToken = process.env.__GLUECLAW_MCP_TOKEN;
+  process.env.MOCK_SCENARIO = "env-echo";
+  process.env.__GLUECLAW_MCP_PORT = "12345";
+  process.env.__GLUECLAW_MCP_TOKEN = "test-token";
+
+  try {
+    const streamFn = createClaudeCliStreamFn({
+      claudeBin: MOCK_CLI,
+      sessionKey: opts.sessionKey ?? `env-${Date.now()}-${Math.random()}`,
+      agentId: opts.agentId,
+      modelOverride: "claude-sonnet-4-6",
+    });
+    const model = {
+      id: "glueclaw-sonnet",
+      api: "anthropic-messages",
+      provider: "glueclaw",
+    } as any;
+    const context = {
+      systemPrompt: "",
+      messages: [{ role: "user" as const, content: "say pong" }],
+    } as any;
+    const stream = await streamFn(model, context, {});
+    let resultText = "";
+    for await (const event of stream) {
+      if ((event as any).type === "done") {
+        resultText = (event as any).message.content[0].text;
+      }
+    }
+    return JSON.parse(resultText);
+  } finally {
+    if (origScenario !== undefined) process.env.MOCK_SCENARIO = origScenario;
+    else delete process.env.MOCK_SCENARIO;
+    if (origPort !== undefined) process.env.__GLUECLAW_MCP_PORT = origPort;
+    else delete process.env.__GLUECLAW_MCP_PORT;
+    if (origToken !== undefined) process.env.__GLUECLAW_MCP_TOKEN = origToken;
+    else delete process.env.__GLUECLAW_MCP_TOKEN;
+  }
+}
+
+describe("MCP agent identity", () => {
+  it("propagates opts.agentId to OPENCLAW_MCP_AGENT_ID", async () => {
+    const env = await captureSubprocessEnv({ agentId: "evacastro" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+  });
+
+  it("uses a different agentId for a different agent", async () => {
+    const env = await captureSubprocessEnv({ agentId: "roy" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("roy");
+  });
+
+  it("falls back to 'main' when opts.agentId is omitted", async () => {
+    const env = await captureSubprocessEnv({});
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("main");
+  });
+
+  it("propagates opts.sessionKey alongside agentId independently", async () => {
+    const env = await captureSubprocessEnv({
+      agentId: "evacastro",
+      sessionKey: "session-xyz",
+    });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+    expect(env.OPENCLAW_MCP_SESSION_KEY).toBe("session-xyz");
+  });
+});

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -195,14 +195,17 @@ export function createClaudeCliStreamFn(opts: {
           "--verbose",
           "--include-partial-messages",
         ];
-        // Resume session for multi-turn conversation memory
+        // Resume session for multi-turn conversation memory.
+        // Always re-inject the system prompt — on resumptions the CLI would
+        // otherwise stick to whatever identity was used on the first turn,
+        // leaving no way for callers to reinforce or correct an agent's
+        // identity across turns.
         const sessionKey = `glueclaw:${opts.sessionKey ?? "default"}`;
         const existingSessionId = sessionMap.get(sessionKey);
         if (existingSessionId) {
           args.push("--resume", existingSessionId);
-        } else {
-          if (cleanPrompt) args.push("--system-prompt", cleanPrompt);
         }
+        if (cleanPrompt) args.push("--system-prompt", cleanPrompt);
         if (resolvedModel) args.push("--model", resolvedModel);
 
         // Debug: log args for resume troubleshooting

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -170,6 +170,7 @@ function evictSessions(): void {
 export function createClaudeCliStreamFn(opts: {
   claudeBin?: string;
   sessionKey?: string;
+  agentId?: string;
   modelOverride?: string;
   requestTimeoutMs?: number;
 }): StreamFn {
@@ -233,7 +234,7 @@ export function createClaudeCliStreamFn(opts: {
           args.push("--strict-mcp-config", "--mcp-config", mcp.path);
           env.OPENCLAW_MCP_TOKEN = loopback.token;
           env.OPENCLAW_MCP_SESSION_KEY = opts.sessionKey ?? "";
-          env.OPENCLAW_MCP_AGENT_ID = "main";
+          env.OPENCLAW_MCP_AGENT_ID = opts.agentId ?? "main";
           env.OPENCLAW_MCP_ACCOUNT_ID = "";
           env.OPENCLAW_MCP_MESSAGE_CHANNEL = "";
         }


### PR DESCRIPTION
Fixes #26.

## Summary
- The system prompt encoding the agent's identity was only passed on the first invocation that created a Claude CLI session. On `--resume`, the CLI does NOT preserve the original system prompt — it falls back to its built-in default. So every turn after the first silently lost the agent's identity, and the CLI even reported `cache_miss_reason: system_changed` of the full system block on every resume.
- Move the `--system-prompt` push out of the `else` branch so the prompt is appended whenever `cleanPrompt` is non-empty, regardless of whether `--resume` is also being passed. The Claude CLI accepts both flags together; the new prompt cleanly replaces (does not merge with) any prior one.

## Empirical verification (real Claude CLI, opus-4-7)
Four-call experiment, same session:

| # | Resume | `--system-prompt` | Response | `cache_miss_reason` |
|---|---|---|---|---|
| 1 | no  | `A: "reply BANANA"` | `BANANA` ✅ | initial |
| 2 | yes | (none — current behavior) | **`Berlin`** ❌ | `system_changed`, **14 322 tokens** |
| 3 | yes | `B: "reply ELEPHANT"` | `ELEPHANT` ✅ | 23 288 tokens |
| 4 | yes | `A` again | `BANANA` ✅ | 1 866 tokens |

Test 2 confirms the bug, test 3 confirms clean replacement (no merge), test 4 confirms re-injecting the same prompt yields a near cache hit.

## Side benefit: less cache thrashing
The original code triggered a `system_changed` miss on every resume because the CLI was alternating between the user-supplied prompt and its default. With the fix, when the upstream sends a stable system prompt across turns the prefix caches normally and the per-resume miss disappears.

## Changes
- `src/stream.ts`: always push `--system-prompt cleanPrompt` when non-empty, regardless of `--resume`.
- `src/__tests__/integration/stream.test.ts`: 4 new tests under `system prompt re-injection on resume` — fresh call, resume re-injects, drift recovery, and empty-prompt fallthrough. Uses the existing `args-echo` mock scenario via a new `captureSubprocessArgs` helper.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (84 passed / 7 skipped — 4 new tests)
- [x] Manual: 4-call run against the real Claude CLI confirming behavior in the table above.
