### PR TITLE
fix: scope Claude CLI sessions per OpenClaw conversation, not per agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The only way this breaks is if Anthropic changes how `--system-prompt` or `--out
 
 Switch in TUI: `/model glueclaw/glueclaw-opus`
 
+## Configuration
+
+| Env var                       | Default  | Description                                                                                                                                                                                                                                                                 |
+| ----------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GLUECLAW_REQUEST_TIMEOUT_MS` | `120000` | Maximum time (in milliseconds) to wait for the Claude CLI subprocess to complete a single request before it is terminated. Increase if long-running tool calls or extensive reasoning trip the default 120s limit. Invalid or non-positive values fall back to the default. |
+
+Example (10 minute timeout):
+
+```bash
+export GLUECLAW_REQUEST_TIMEOUT_MS=600000
+```
+
 ## Notes
 
 - Tested with Telegram and OpenClaw TUI

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,17 @@ const MODEL_MAP: Readonly<Record<string, string>> = {
   "glueclaw-haiku": "claude-haiku-4-5",
 };
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
+function resolveRequestTimeoutMs(): number {
+  const raw = process.env.GLUECLAW_REQUEST_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_REQUEST_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    return DEFAULT_REQUEST_TIMEOUT_MS;
+  return parsed;
+}
+
 export default definePluginEntry({
   register(api: OpenClawPluginApi): void {
     const authProfile = () =>
@@ -77,6 +88,7 @@ export default definePluginEntry({
           sessionKey: ctx.agentDir ?? "default",
           agentId,
           modelOverride: realModel,
+          requestTimeoutMs: resolveRequestTimeoutMs(),
         });
       },
       resolveSyntheticAuth: () => ({

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createClaudeCliStreamFn } from "./src/stream.js";
 import { MODEL_CATALOG } from "./src/catalog.js";
+import { resolveSessionKey } from "./src/session-key.js";
 
 const PROVIDER_ID = "glueclaw";
 const PROVIDER_LABEL = "GlueClaw";
@@ -81,11 +82,16 @@ export default definePluginEntry({
           },
         }),
       },
-      createStreamFn: (ctx: { modelId: string; agentDir?: string }) => {
+      createStreamFn: (ctx: {
+        modelId: string;
+        agentDir?: string;
+        sessionId?: string;
+        sessionKey?: string;
+      }) => {
         const realModel = MODEL_MAP[ctx.modelId] ?? ctx.modelId;
         const agentId = ctx.agentDir ? basename(ctx.agentDir) : undefined;
         return createClaudeCliStreamFn({
-          sessionKey: ctx.agentDir ?? "default",
+          sessionKey: resolveSessionKey(ctx),
           agentId,
           modelOverride: realModel,
           requestTimeoutMs: resolveRequestTimeoutMs(),

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import {
   definePluginEntry,
   type OpenClawPluginApi,
@@ -71,8 +72,10 @@ export default definePluginEntry({
       },
       createStreamFn: (ctx: { modelId: string; agentDir?: string }) => {
         const realModel = MODEL_MAP[ctx.modelId] ?? ctx.modelId;
+        const agentId = ctx.agentDir ? basename(ctx.agentDir) : undefined;
         return createClaudeCliStreamFn({
           sessionKey: ctx.agentDir ?? "default",
+          agentId,
           modelOverride: realModel,
         });
       },

--- a/src/__tests__/integration/mock-claude.mjs
+++ b/src/__tests__/integration/mock-claude.mjs
@@ -116,6 +116,20 @@ switch (scenario) {
     });
     break;
 
+  case "env-echo":
+    emit({ type: "system", subtype: "init", session_id: sessionId });
+    emit({
+      type: "result",
+      session_id: sessionId,
+      result: JSON.stringify({
+        OPENCLAW_MCP_AGENT_ID: process.env.OPENCLAW_MCP_AGENT_ID ?? null,
+        OPENCLAW_MCP_SESSION_KEY: process.env.OPENCLAW_MCP_SESSION_KEY ?? null,
+        OPENCLAW_MCP_TOKEN: process.env.OPENCLAW_MCP_TOKEN ?? null,
+      }),
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    break;
+
   case "hang":
     // Emit init then hang forever — never emits result
     emit({ type: "system", subtype: "init", session_id: sessionId });

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -412,3 +412,117 @@ describe("MCP agent identity", () => {
     expect(env.OPENCLAW_MCP_SESSION_KEY).toBe("session-xyz");
   });
 });
+
+/**
+ * Capture the args the Claude CLI subprocess was invoked with. Uses the
+ * args-echo mock scenario which emits the argv slice as the result text.
+ */
+async function captureSubprocessArgs(opts: {
+  sessionKey: string;
+  systemPrompt: string;
+  mockSessionId?: string;
+}): Promise<string[]> {
+  const origScenario = process.env.MOCK_SCENARIO;
+  const origMockSession = process.env.MOCK_SESSION_ID;
+  process.env.MOCK_SCENARIO = "args-echo";
+  if (opts.mockSessionId !== undefined)
+    process.env.MOCK_SESSION_ID = opts.mockSessionId;
+
+  try {
+    const streamFn = createClaudeCliStreamFn({
+      claudeBin: MOCK_CLI,
+      sessionKey: opts.sessionKey,
+      modelOverride: "claude-sonnet-4-6",
+    });
+    const model = {
+      id: "glueclaw-sonnet",
+      api: "anthropic-messages",
+      provider: "glueclaw",
+    } as any;
+    const context = {
+      systemPrompt: opts.systemPrompt,
+      messages: [{ role: "user" as const, content: "hi" }],
+    } as any;
+    const stream = await streamFn(model, context, {});
+    let resultText = "";
+    for await (const event of stream) {
+      if ((event as any).type === "done") {
+        resultText = (event as any).message.content[0].text;
+      }
+    }
+    return JSON.parse(resultText);
+  } finally {
+    if (origScenario !== undefined) process.env.MOCK_SCENARIO = origScenario;
+    else delete process.env.MOCK_SCENARIO;
+    if (origMockSession !== undefined)
+      process.env.MOCK_SESSION_ID = origMockSession;
+    else delete process.env.MOCK_SESSION_ID;
+  }
+}
+
+describe("system prompt re-injection on resume", () => {
+  it("includes --system-prompt on the first (fresh) call", async () => {
+    const args = await captureSubprocessArgs({
+      sessionKey: `sp-fresh-${Date.now()}-${Math.random()}`,
+      systemPrompt: "You are persona ALPHA.",
+    });
+    expect(args).toContain("--system-prompt");
+    const idx = args.indexOf("--system-prompt");
+    expect(args[idx + 1]).toBe("You are persona ALPHA.");
+    expect(args).not.toContain("--resume");
+  });
+
+  it("includes BOTH --resume and --system-prompt on subsequent calls", async () => {
+    const sessionKey = `sp-resume-${Date.now()}-${Math.random()}`;
+    const mockSessionId = `mock-sid-${Date.now()}`;
+
+    // First call populates sessionMap via the mock's system/init event.
+    await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are persona BETA.",
+      mockSessionId,
+    });
+
+    // Second call should resume AND re-inject the system prompt.
+    const args = await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are persona BETA.",
+      mockSessionId,
+    });
+    expect(args).toContain("--resume");
+    const resumeIdx = args.indexOf("--resume");
+    expect(args[resumeIdx + 1]).toBe(mockSessionId);
+    expect(args).toContain("--system-prompt");
+    const spIdx = args.indexOf("--system-prompt");
+    expect(args[spIdx + 1]).toBe("You are persona BETA.");
+  });
+
+  it("re-injects an updated system prompt on resume (identity drift recovery)", async () => {
+    const sessionKey = `sp-drift-${Date.now()}-${Math.random()}`;
+    const mockSessionId = `mock-sid-drift-${Date.now()}`;
+
+    await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are agent A (original).",
+      mockSessionId,
+    });
+
+    const args = await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are agent A (corrected).",
+      mockSessionId,
+    });
+    expect(args).toContain("--resume");
+    const spIdx = args.indexOf("--system-prompt");
+    expect(spIdx).toBeGreaterThanOrEqual(0);
+    expect(args[spIdx + 1]).toBe("You are agent A (corrected).");
+  });
+
+  it("omits --system-prompt entirely when no system prompt is provided", async () => {
+    const args = await captureSubprocessArgs({
+      sessionKey: `sp-empty-${Date.now()}-${Math.random()}`,
+      systemPrompt: "",
+    });
+    expect(args).not.toContain("--system-prompt");
+  });
+});

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -336,3 +336,79 @@ describe("concurrency", () => {
     }
   });
 });
+
+/**
+ * Run a stream against the env-echo scenario and return the parsed env snapshot
+ * the subprocess saw. Requires MCP loopback env vars to be set on process.env
+ * so stream.ts wires up OPENCLAW_MCP_AGENT_ID/SESSION_KEY/TOKEN at all.
+ */
+async function captureSubprocessEnv(opts: {
+  agentId?: string;
+  sessionKey?: string;
+}): Promise<Record<string, string | null>> {
+  const origScenario = process.env.MOCK_SCENARIO;
+  const origPort = process.env.__GLUECLAW_MCP_PORT;
+  const origToken = process.env.__GLUECLAW_MCP_TOKEN;
+  process.env.MOCK_SCENARIO = "env-echo";
+  process.env.__GLUECLAW_MCP_PORT = "12345";
+  process.env.__GLUECLAW_MCP_TOKEN = "test-token";
+
+  try {
+    const streamFn = createClaudeCliStreamFn({
+      claudeBin: MOCK_CLI,
+      sessionKey: opts.sessionKey ?? `env-${Date.now()}-${Math.random()}`,
+      agentId: opts.agentId,
+      modelOverride: "claude-sonnet-4-6",
+    });
+    const model = {
+      id: "glueclaw-sonnet",
+      api: "anthropic-messages",
+      provider: "glueclaw",
+    } as any;
+    const context = {
+      systemPrompt: "",
+      messages: [{ role: "user" as const, content: "say pong" }],
+    } as any;
+    const stream = await streamFn(model, context, {});
+    let resultText = "";
+    for await (const event of stream) {
+      if ((event as any).type === "done") {
+        resultText = (event as any).message.content[0].text;
+      }
+    }
+    return JSON.parse(resultText);
+  } finally {
+    if (origScenario !== undefined) process.env.MOCK_SCENARIO = origScenario;
+    else delete process.env.MOCK_SCENARIO;
+    if (origPort !== undefined) process.env.__GLUECLAW_MCP_PORT = origPort;
+    else delete process.env.__GLUECLAW_MCP_PORT;
+    if (origToken !== undefined) process.env.__GLUECLAW_MCP_TOKEN = origToken;
+    else delete process.env.__GLUECLAW_MCP_TOKEN;
+  }
+}
+
+describe("MCP agent identity", () => {
+  it("propagates opts.agentId to OPENCLAW_MCP_AGENT_ID", async () => {
+    const env = await captureSubprocessEnv({ agentId: "evacastro" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+  });
+
+  it("uses a different agentId for a different agent", async () => {
+    const env = await captureSubprocessEnv({ agentId: "roy" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("roy");
+  });
+
+  it("falls back to 'main' when opts.agentId is omitted", async () => {
+    const env = await captureSubprocessEnv({});
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("main");
+  });
+
+  it("propagates opts.sessionKey alongside agentId independently", async () => {
+    const env = await captureSubprocessEnv({
+      agentId: "evacastro",
+      sessionKey: "session-xyz",
+    });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+    expect(env.OPENCLAW_MCP_SESSION_KEY).toBe("session-xyz");
+  });
+});

--- a/src/__tests__/unit/pure-functions.test.ts
+++ b/src/__tests__/unit/pure-functions.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../stream.js";
 import { MODEL_CATALOG } from "../../catalog.js";
 import { binarySearchTrigger } from "../../healthcheck.js";
+import { resolveSessionKey } from "../../session-key.js";
 
 describe("buildUsage", () => {
   it("returns zeroed usage when called with undefined", () => {
@@ -356,5 +357,71 @@ describe("binarySearchTrigger", () => {
     const testFn = async (chunk: string) => !chunk.includes("TRIGGER");
     const result = await binarySearchTrigger(lines, testFn);
     expect(result).toBe("TRIGGER");
+  });
+});
+
+describe("resolveSessionKey", () => {
+  it("prefers sessionKey over everything else", () => {
+    expect(
+      resolveSessionKey({
+        sessionKey: "telegram:dm:+34xxx",
+        sessionId: "abc-uuid",
+        agentDir: "/home/x/.openclaw/agents/eva",
+      }),
+    ).toBe("telegram:dm:+34xxx");
+  });
+
+  it("falls back to sessionId when sessionKey is absent", () => {
+    expect(
+      resolveSessionKey({
+        sessionId: "conv-uuid-1",
+        agentDir: "/home/x/.openclaw/agents/eva",
+      }),
+    ).toBe("conv-uuid-1");
+  });
+
+  it("falls back to agentDir when sessionKey and sessionId are absent", () => {
+    expect(
+      resolveSessionKey({
+        agentDir: "/home/x/.openclaw/agents/eva",
+      }),
+    ).toBe("/home/x/.openclaw/agents/eva");
+  });
+
+  it("falls back to 'default' when nothing is provided", () => {
+    expect(resolveSessionKey({})).toBe("default");
+  });
+
+  it("yields distinct keys for two conversations of the same agent (the bug fix)", () => {
+    const agentDir = "/home/x/.openclaw/agents/eva";
+    const a = resolveSessionKey({
+      sessionKey: "telegram:dm:userA",
+      agentDir,
+    });
+    const b = resolveSessionKey({
+      sessionKey: "telegram:dm:userB",
+      agentDir,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("yields the same key across turns of one conversation (resumption stability)", () => {
+    const ctx = {
+      sessionKey: "telegram:group:abc:user:def",
+      sessionId: "rotating-uuid-on-reset",
+      agentDir: "/home/x/.openclaw/agents/eva",
+    };
+    expect(resolveSessionKey(ctx)).toBe(resolveSessionKey(ctx));
+  });
+
+  it("treats empty string as a valid value (does not skip to fallback)", () => {
+    // Empty strings are unlikely in practice but we should not silently
+    // collapse them — only undefined triggers fallback.
+    expect(
+      resolveSessionKey({
+        sessionKey: "",
+        sessionId: "would-be-skipped",
+      }),
+    ).toBe("would-be-skipped");
   });
 });

--- a/src/session-key.ts
+++ b/src/session-key.ts
@@ -1,0 +1,27 @@
+/**
+ * Pick the most specific identity-bearing key OpenClaw exposed for this
+ * conversation, so each conversation gets its own Claude CLI session.
+ *
+ * Precedence:
+ *   1. `sessionKey` — semantic, stable across session resets for the same
+ *      logical conversation (channel/group/sender-encoded). Best.
+ *   2. `sessionId` — UUID of the current `<uuid>.jsonl` file. Rotates on reset.
+ *   3. `agentDir` — collapses all conversations of one agent into one bucket.
+ *      Used only when OpenClaw is older than openclaw/openclaw#73488 and
+ *      doesn't propagate session identity to provider plugins.
+ *   4. `"default"` — final safety net; should never hit in practice.
+ */
+export function resolveSessionKey(ctx: {
+  sessionKey?: string;
+  sessionId?: string;
+  agentDir?: string;
+}): string {
+  const pick = (...candidates: Array<string | undefined>) => {
+    for (const c of candidates) {
+      const trimmed = c?.trim();
+      if (trimmed) return trimmed;
+    }
+    return undefined;
+  };
+  return pick(ctx.sessionKey, ctx.sessionId, ctx.agentDir) ?? "default";
+}

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -195,14 +195,17 @@ export function createClaudeCliStreamFn(opts: {
           "--verbose",
           "--include-partial-messages",
         ];
-        // Resume session for multi-turn conversation memory
+        // Resume session for multi-turn conversation memory.
+        // Always re-inject the system prompt — on resumptions the CLI would
+        // otherwise stick to whatever identity was used on the first turn,
+        // leaving no way for callers to reinforce or correct an agent's
+        // identity across turns.
         const sessionKey = `glueclaw:${opts.sessionKey ?? "default"}`;
         const existingSessionId = sessionMap.get(sessionKey);
         if (existingSessionId) {
           args.push("--resume", existingSessionId);
-        } else {
-          if (cleanPrompt) args.push("--system-prompt", cleanPrompt);
         }
+        if (cleanPrompt) args.push("--system-prompt", cleanPrompt);
         if (resolvedModel) args.push("--model", resolvedModel);
 
         // Debug: log args for resume troubleshooting

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -170,6 +170,7 @@ function evictSessions(): void {
 export function createClaudeCliStreamFn(opts: {
   claudeBin?: string;
   sessionKey?: string;
+  agentId?: string;
   modelOverride?: string;
   requestTimeoutMs?: number;
 }): StreamFn {
@@ -233,7 +234,7 @@ export function createClaudeCliStreamFn(opts: {
           args.push("--strict-mcp-config", "--mcp-config", mcp.path);
           env.OPENCLAW_MCP_TOKEN = loopback.token;
           env.OPENCLAW_MCP_SESSION_KEY = opts.sessionKey ?? "";
-          env.OPENCLAW_MCP_AGENT_ID = "main";
+          env.OPENCLAW_MCP_AGENT_ID = opts.agentId ?? "main";
           env.OPENCLAW_MCP_ACCOUNT_ID = "";
           env.OPENCLAW_MCP_MESSAGE_CHANNEL = "";
         }


### PR DESCRIPTION
Fixes #28. Pairs with openclaw/openclaw#73488 / openclaw/openclaw#73492.

## Summary
- The plugin's session map was keyed by `agentDir`, which collapsed all of an agent's concurrent conversations into a single Claude CLI session. Two DMs and a group on the same agent resume against the same underlying CLI process, leaking transcripts between conversations.
- OpenClaw owns the per-conversation identity (`sessionKey`, `sessionId`) but historically did not propagate it to provider plugins. The companion change in openclaw exposes both fields in `ProviderCreateStreamFnContext`. This PR consumes them with a clear precedence.

## Precedence
1. `ctx.sessionKey` — semantic, stable across session resets for the same logical conversation.
2. `ctx.sessionId` — UUID fallback, rotates on reset.
3. `ctx.agentDir` — historical behavior, used when running against an OpenClaw build older than openclaw#73492.
4. `"default"` — final safety net.

## Changes
- `src/session-key.ts`: new pure helper `resolveSessionKey`.
- `index.ts`: read the new optional `sessionId`/`sessionKey` fields from `ctx` and feed them through `resolveSessionKey`.
- `src/__tests__/unit/pure-functions.test.ts`: 7 new tests — precedence, distinctness across conversations, stability across turns, empty-string guard, fallback chains.

## Forward / backward compatibility
Against current OpenClaw, `ctx.sessionKey` and `ctx.sessionId` are `undefined` and behavior collapses to historical per-agent (the bug). The fix is a no-op until openclaw ships the upstream context change, then auto-activates. Safe to merge independently of openclaw#73492.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (91 / 7 skipped — 7 new unit tests)
- [ ] End-to-end verification: requires a local OpenClaw built from openclaw#73492.
