### PR TITLE
feat: bootstrap OpenClaw MCP loopback in-process to expose session tools natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ The only way this breaks is if Anthropic changes how `--system-prompt` or `--out
 
 Switch in TUI: `/model glueclaw/glueclaw-opus`
 
+## Configuration
+
+| Env var                       | Default  | Description                                                                                                                                                                                                                                                                 |
+| ----------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GLUECLAW_REQUEST_TIMEOUT_MS` | `120000` | Maximum time (in milliseconds) to wait for the Claude CLI subprocess to complete a single request before it is terminated. Increase if long-running tool calls or extensive reasoning trip the default 120s limit. Invalid or non-positive values fall back to the default. |
+
+Example (10 minute timeout):
+
+```bash
+export GLUECLAW_REQUEST_TIMEOUT_MS=600000
+```
+
 ## Notes
 
 - Tested with Telegram and OpenClaw TUI

--- a/docs/RFC-001-sessions-send-native.md
+++ b/docs/RFC-001-sessions-send-native.md
@@ -1,0 +1,152 @@
+# RFC-001: `sessions_send` as a native tool inside GlueClaw sessions
+
+**Status:** Implemented
+
+---
+
+## Problem
+
+Agents running through GlueClaw cannot use `sessions_send` (and other OpenClaw
+session tools) as native tools inside their Claude session. The tool is
+described in the system prompt but is never injected as a real function call.
+
+Independent verification confirmed that inter-agent messages are only treated
+as legitimate when they arrive carrying the `Agent 1 (requester) session:
+agent:<id>:...` context inside the `extraSystemPrompt`. That context is only
+stamped by the gateway when the message flows through the official
+`sessions_send` path — not when it is sent from an external script via direct
+WebSocket RPC.
+
+---
+
+## Root cause
+
+OpenClaw exposes session tools to the Claude subprocess via a temporary HTTP
+**MCP loopback** server, started by `ensureMcpLoopbackServer()`. The Claude
+subprocess receives `--mcp-config <file>` pointing at that server.
+
+`ensureMcpLoopbackServer()` is only bootstrapped automatically when the
+resolved backend has `bundleMcp: true` — set today on CLI-style backends
+(Codex, Google CLI) but **not** on provider-style backends like GlueClaw.
+`bundleMcp` is a backend-registration flag, not an `openclaw.json` field, so
+this cannot be fixed from configuration alone.
+
+As a result, GlueClaw never bootstraps the loopback, so the Claude
+subprocess is launched without `--mcp-config` and the gateway's session
+tools are never exposed natively.
+
+---
+
+## Solution
+
+GlueClaw **runs in-process inside the gateway** as a provider plugin. That
+means it shares OpenClaw's ESM module cache: importing the same
+`mcp-http-*.js` file the gateway loaded gives us back the singleton
+runtime, and any `ensureMcpLoopbackServer()` already running becomes a no-op.
+
+`src/stream.ts` exports an async `getMcpLoopback()` that:
+
+1. Locates OpenClaw's `dist/` by inspecting `process.env.NODE_PATH` (the
+   gateway sets it to `<install-root>/node_modules:...` before invoking
+   plugins).
+2. Imports the `mcp-http-*.js` module via a `file://` URL — same path,
+   same module cache key, same singleton.
+3. Calls `ensureMcpLoopbackServer()` (idempotent).
+4. Calls `getActiveMcpLoopbackRuntime()` to read the live `{ port,
+   ownerToken }` directly out of memory.
+5. Caches the result for subsequent invocations.
+
+The Claude subprocess is then spawned with `--mcp-config` pointing at a
+temp file that wires the loopback URL + token into the MCP client headers.
+
+### Why this is safe
+
+- **Idempotent:** repeated calls hit the singleton; no port races.
+- **Module-cache-shared:** `await import("file://.../mcp-http-*.js")`
+  returns the same module instance the gateway already loaded — no
+  duplicate state.
+- **Failure is benign:** if the OpenClaw dist cannot be located or
+  exports a renamed/incompatible API, the function returns `undefined`
+  and the session runs without session tools — the same degraded state
+  GlueClaw had before this RFC.
+- **No mutation of the OpenClaw dist:** unlike the previous approach,
+  this design does **not** touch any minified bundle or rely on regex
+  patches against internal variable names.
+
+### Minified-export aliases
+
+The bundle exports session-tool helpers under terse aliases. We look up
+both the alias and the original name so the code keeps working if a
+future OpenClaw build switches them:
+
+| Alias | Original |
+|-------|----------|
+| `n`   | `ensureMcpLoopbackServer` |
+| `i`   | `getActiveMcpLoopbackRuntime` |
+| `r`   | `createMcpLoopbackServerConfig` |
+| `t`   | `closeMcpLoopbackServer` |
+
+---
+
+## Why this replaces the old `install.sh` patch
+
+A previous version of `install.sh` patched OpenClaw's
+`mcp-http-CFgfguST.js` with `sed`, injecting:
+
+```js
+process.env.__GLUECLAW_MCP_PORT = String(address.port);
+process.env.__GLUECLAW_MCP_TOKEN = token;
+```
+
+The intent was to leak the loopback's `port`/`token` out through
+environment variables so a separate `getMcpLoopback()` function could
+read them. Two problems:
+
+1. **Latent bug.** In OpenClaw 2026.4.24 the bundle has two tokens in
+   that scope (`ownerToken` and `nonOwnerToken`); the bare identifier
+   `token` is undefined and `ensureMcpLoopbackServer()` throws
+   `ReferenceError: token is not defined`. The bug never manifested
+   before this RFC because GlueClaw never reached that code path.
+2. **Fragile.** Any rename inside OpenClaw's bundle silently breaks the
+   `sed` regex on the next `install.sh` run after an OpenClaw update.
+
+The new design discards the patch entirely. `install.sh` no longer
+modifies any file outside the GlueClaw repo; the MCP bridge step is
+gone (was step 6/7, now removed).
+
+---
+
+## Implementation context
+
+- **File:** `src/stream.ts` (only)
+- **No build step required:** OpenClaw loads the TypeScript directly via
+  `tsx` (the plugin is registered with `--link`).
+- **Requires:** restart the gateway (`systemctl --user restart
+  openclaw-gateway`) so the new module is imported.
+- **No OpenClaw dist mutation.** If a previous `install.sh` ran a `sed`
+  patch against `mcp-http-*.js`, restore it from the upstream npm
+  package or remove the inserted prefix manually before restarting.
+
+---
+
+## Post-implementation verification
+
+1. Restart the gateway.
+2. Send a message to an agent.
+3. Verify in `/proc/<claude-pid>/cmdline` that the spawned `claude`
+   subprocess is invoked with `--mcp-config <path>`.
+4. From the active agent session, call `sessions_send` — it must execute
+   as a native function call, not as external WebSocket RPC.
+5. The receiving agent must get `Agent 1 (requester) session:
+   agent:<id>:...` in its `extraSystemPrompt`.
+
+---
+
+## Discarded alternatives
+
+| Option | Why not |
+|--------|---------|
+| `bundleMcp: true` in `openclaw.json` | Not a config field — only a backend registration property |
+| External script + WebSocket `sessions.send` | Does not inject the inter-agent authentication `extraSystemPrompt` |
+| `sed`-patch the OpenClaw dist + leak via `process.env` | Fragile against bundle renames; latent bug already discovered (`token is not defined`); unnecessary because GlueClaw is in-process |
+| Register GlueClaw as a CLI backend instead of a provider | Major architectural change, incompatible with the current provider model |

--- a/index.ts
+++ b/index.ts
@@ -19,6 +19,17 @@ const MODEL_MAP: Readonly<Record<string, string>> = {
   "glueclaw-haiku": "claude-haiku-4-5",
 };
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
+function resolveRequestTimeoutMs(): number {
+  const raw = process.env.GLUECLAW_REQUEST_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_REQUEST_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    return DEFAULT_REQUEST_TIMEOUT_MS;
+  return parsed;
+}
+
 export default definePluginEntry({
   register(api: OpenClawPluginApi): void {
     const authProfile = () =>
@@ -77,6 +88,7 @@ export default definePluginEntry({
           sessionKey: ctx.agentDir ?? "default",
           agentId,
           modelOverride: realModel,
+          requestTimeoutMs: resolveRequestTimeoutMs(),
         });
       },
       resolveSyntheticAuth: () => ({

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createClaudeCliStreamFn } from "./src/stream.js";
 import { MODEL_CATALOG } from "./src/catalog.js";
+import { resolveSessionKey } from "./src/session-key.js";
 
 const PROVIDER_ID = "glueclaw";
 const PROVIDER_LABEL = "GlueClaw";
@@ -81,11 +82,16 @@ export default definePluginEntry({
           },
         }),
       },
-      createStreamFn: (ctx: { modelId: string; agentDir?: string }) => {
+      createStreamFn: (ctx: {
+        modelId: string;
+        agentDir?: string;
+        sessionId?: string;
+        sessionKey?: string;
+      }) => {
         const realModel = MODEL_MAP[ctx.modelId] ?? ctx.modelId;
         const agentId = ctx.agentDir ? basename(ctx.agentDir) : undefined;
         return createClaudeCliStreamFn({
-          sessionKey: ctx.agentDir ?? "default",
+          sessionKey: resolveSessionKey(ctx),
           agentId,
           modelOverride: realModel,
           requestTimeoutMs: resolveRequestTimeoutMs(),

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import {
   definePluginEntry,
   type OpenClawPluginApi,
@@ -71,8 +72,10 @@ export default definePluginEntry({
       },
       createStreamFn: (ctx: { modelId: string; agentDir?: string }) => {
         const realModel = MODEL_MAP[ctx.modelId] ?? ctx.modelId;
+        const agentId = ctx.agentDir ? basename(ctx.agentDir) : undefined;
         return createClaudeCliStreamFn({
           sessionKey: ctx.agentDir ?? "default",
+          agentId,
           modelOverride: realModel,
         });
       },

--- a/install.sh
+++ b/install.sh
@@ -29,14 +29,6 @@ oc_config() {
   }
 }
 
-sedi() {
-  if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' "$@"
-  else
-    sed -i "$@"
-  fi
-}
-
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || die "$1 not found. $2"
 }
@@ -121,14 +113,6 @@ else
 fi
 echo ""
 
-# Find OpenClaw dist
-OPENCLAW_BIN="$(command -v openclaw)"
-OPENCLAW_ROOT="$(dirname "$OPENCLAW_BIN")/../lib/node_modules/openclaw"
-# Suppress not-found: fallback path may not exist
-[ ! -d "$OPENCLAW_ROOT/dist" ] && OPENCLAW_ROOT="$(npm root -g 2>/dev/null)/openclaw"
-[ ! -d "$OPENCLAW_ROOT/dist" ] && die "Cannot find OpenClaw dist"
-OPENCLAW_DIST="$OPENCLAW_ROOT/dist"
-
 # Detect shell config
 if [ -f "${HOME}/.zshrc" ]; then
   SHELL_RC="${HOME}/.zshrc"
@@ -142,17 +126,7 @@ fi
 
 GW_PID=""
 GW_LOG=""
-BACKUP_FILE=""
 cleanup() {
-  # Restore MCP patch backup if script failed mid-patch
-  if [ -n "$BACKUP_FILE" ] && [ -f "$BACKUP_FILE" ]; then
-    if [ -w "$(dirname "$BACKUP_FILE")" ]; then
-      mv "$BACKUP_FILE" "${BACKUP_FILE%.glueclaw-bak}" 2>/dev/null || true
-    else
-      sudo mv "$BACKUP_FILE" "${BACKUP_FILE%.glueclaw-bak}" 2>/dev/null || true
-    fi
-    echo "  Restored backup: $(basename "$BACKUP_FILE")" >&2
-  fi
   if [ -n "$GW_PID" ] && kill -0 "$GW_PID" 2>/dev/null; then
     kill "$GW_PID" 2>/dev/null || true
   fi
@@ -162,19 +136,19 @@ trap cleanup INT TERM
 
 # --- 1. Dependencies ---
 
-echo "[1/7] Installing dependencies..."
+echo "[1/6] Installing dependencies..."
 cd "$PLUGIN_DIR"
 npm install --silent || die "npm install failed"
 
 # --- 2. Environment ---
 
-echo "[2/7] Setting up environment..."
+echo "[2/6] Setting up environment..."
 ensure_line "$SHELL_RC" "GLUECLAW_KEY" "export GLUECLAW_KEY=local"
 export GLUECLAW_KEY=local
 
 # --- 3. Plugin registration ---
 
-echo "[3/7] Registering plugin..."
+echo "[3/6] Registering plugin..."
 # GlueClaw is on OpenClaw's official safe plugin list. Try standard install first,
 # fall back to --dangerously-force-unsafe-install for older OpenClaw versions,
 # then manual config as last resort.
@@ -188,7 +162,7 @@ fi
 
 # --- 4. Model config ---
 
-echo "[4/7] Configuring models..."
+echo "[4/6] Configuring models..."
 # These two are fatal — without them, nothing works
 oc_config models.providers.glueclaw \
   '{"baseUrl":"local://glueclaw","models":[{"id":"glueclaw-opus","name":"GlueClaw Opus","contextWindow":1000000},{"id":"glueclaw-sonnet","name":"GlueClaw Sonnet","contextWindow":1000000},{"id":"glueclaw-haiku","name":"GlueClaw Haiku","contextWindow":200000}]}' \
@@ -211,47 +185,20 @@ oc_config gateway.tools.allow \
 
 # --- 5. Auth profile ---
 
-echo "[5/7] Setting up auth..."
+echo "[5/6] Setting up auth..."
 AGENT_DIR="${HOME}/.openclaw/agents/main/agent"
 mkdir -p "$AGENT_DIR" || die "Cannot create $AGENT_DIR"
 AUTH_FILE="$AGENT_DIR/auth-profiles.json"
 write_auth_profile "$AUTH_FILE"
 
-# --- 6. Patch: MCP bridge ---
+# --- 6. Restart gateway ---
+# Note: GlueClaw bootstraps OpenClaw's MCP loopback in-process from
+# src/stream.ts (see docs/RFC-001-sessions-send-native.md). No dist patching
+# is needed — GlueClaw shares OpenClaw's module cache as an in-process
+# provider, so calling ensureMcpLoopbackServer() and getActiveMcpLoopbackRuntime()
+# directly is sufficient.
 
-echo "[6/7] Patching gateway for MCP bridge..."
-SERVER_FILE=$(grep -rl "mcp loopback listening" "$OPENCLAW_DIST"/*.js 2>/dev/null | head -n 1)
-[ -z "$SERVER_FILE" ] && die "Cannot find MCP loopback in OpenClaw dist — incompatible version?"
-
-# Use sudo for file operations if dist directory is not writable (global npm install)
-ELEVATE=""
-if [ ! -w "$OPENCLAW_DIST" ]; then
-  echo "  OpenClaw dist is root-owned, using sudo for patch..."
-  ELEVATE="sudo"
-fi
-
-if ! grep -q "__GLUECLAW_MCP" "$SERVER_FILE"; then
-  $ELEVATE cp "$SERVER_FILE" "${SERVER_FILE}.glueclaw-bak" || die "Cannot backup $SERVER_FILE"
-  BACKUP_FILE="${SERVER_FILE}.glueclaw-bak"
-  # shellcheck disable=SC2016
-  if [ -n "$ELEVATE" ]; then
-    $ELEVATE sed -i 's/logDebug(`mcp loopback listening/process.env.__GLUECLAW_MCP_PORT = String(address.port); process.env.__GLUECLAW_MCP_TOKEN = token; logDebug(`mcp loopback listening/' "$SERVER_FILE" ||
-      die "Failed to patch $SERVER_FILE"
-  else
-    sedi 's/logDebug(`mcp loopback listening/process.env.__GLUECLAW_MCP_PORT = String(address.port); process.env.__GLUECLAW_MCP_TOKEN = token; logDebug(`mcp loopback listening/' "$SERVER_FILE" ||
-      die "Failed to patch $SERVER_FILE"
-  fi
-  # Validate the patch actually applied
-  grep -q "__GLUECLAW_MCP_PORT" "$SERVER_FILE" || die "MCP patch did not apply — sed replacement failed"
-  BACKUP_FILE=""  # Patch succeeded, don't restore on cleanup
-  echo "  Patched $(basename "$SERVER_FILE")"
-else
-  echo "  Already patched"
-fi
-
-# --- 7. Restart gateway ---
-
-echo "[7/7] Starting gateway..."
+echo "[6/6] Starting gateway..."
 # Stop any existing gateway first
 pkill -f "openclaw.*gateway" 2>/dev/null || true
 openclaw gateway stop 2>/dev/null || true

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@anthropic-ai/sdk": {

--- a/src/__tests__/integration/mock-claude.mjs
+++ b/src/__tests__/integration/mock-claude.mjs
@@ -116,6 +116,20 @@ switch (scenario) {
     });
     break;
 
+  case "env-echo":
+    emit({ type: "system", subtype: "init", session_id: sessionId });
+    emit({
+      type: "result",
+      session_id: sessionId,
+      result: JSON.stringify({
+        OPENCLAW_MCP_AGENT_ID: process.env.OPENCLAW_MCP_AGENT_ID ?? null,
+        OPENCLAW_MCP_SESSION_KEY: process.env.OPENCLAW_MCP_SESSION_KEY ?? null,
+        OPENCLAW_MCP_TOKEN: process.env.OPENCLAW_MCP_TOKEN ?? null,
+      }),
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    break;
+
   case "hang":
     // Emit init then hang forever — never emits result
     emit({ type: "system", subtype: "init", session_id: sessionId });

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -412,3 +412,117 @@ describe("MCP agent identity", () => {
     expect(env.OPENCLAW_MCP_SESSION_KEY).toBe("session-xyz");
   });
 });
+
+/**
+ * Capture the args the Claude CLI subprocess was invoked with. Uses the
+ * args-echo mock scenario which emits the argv slice as the result text.
+ */
+async function captureSubprocessArgs(opts: {
+  sessionKey: string;
+  systemPrompt: string;
+  mockSessionId?: string;
+}): Promise<string[]> {
+  const origScenario = process.env.MOCK_SCENARIO;
+  const origMockSession = process.env.MOCK_SESSION_ID;
+  process.env.MOCK_SCENARIO = "args-echo";
+  if (opts.mockSessionId !== undefined)
+    process.env.MOCK_SESSION_ID = opts.mockSessionId;
+
+  try {
+    const streamFn = createClaudeCliStreamFn({
+      claudeBin: MOCK_CLI,
+      sessionKey: opts.sessionKey,
+      modelOverride: "claude-sonnet-4-6",
+    });
+    const model = {
+      id: "glueclaw-sonnet",
+      api: "anthropic-messages",
+      provider: "glueclaw",
+    } as any;
+    const context = {
+      systemPrompt: opts.systemPrompt,
+      messages: [{ role: "user" as const, content: "hi" }],
+    } as any;
+    const stream = await streamFn(model, context, {});
+    let resultText = "";
+    for await (const event of stream) {
+      if ((event as any).type === "done") {
+        resultText = (event as any).message.content[0].text;
+      }
+    }
+    return JSON.parse(resultText);
+  } finally {
+    if (origScenario !== undefined) process.env.MOCK_SCENARIO = origScenario;
+    else delete process.env.MOCK_SCENARIO;
+    if (origMockSession !== undefined)
+      process.env.MOCK_SESSION_ID = origMockSession;
+    else delete process.env.MOCK_SESSION_ID;
+  }
+}
+
+describe("system prompt re-injection on resume", () => {
+  it("includes --system-prompt on the first (fresh) call", async () => {
+    const args = await captureSubprocessArgs({
+      sessionKey: `sp-fresh-${Date.now()}-${Math.random()}`,
+      systemPrompt: "You are persona ALPHA.",
+    });
+    expect(args).toContain("--system-prompt");
+    const idx = args.indexOf("--system-prompt");
+    expect(args[idx + 1]).toBe("You are persona ALPHA.");
+    expect(args).not.toContain("--resume");
+  });
+
+  it("includes BOTH --resume and --system-prompt on subsequent calls", async () => {
+    const sessionKey = `sp-resume-${Date.now()}-${Math.random()}`;
+    const mockSessionId = `mock-sid-${Date.now()}`;
+
+    // First call populates sessionMap via the mock's system/init event.
+    await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are persona BETA.",
+      mockSessionId,
+    });
+
+    // Second call should resume AND re-inject the system prompt.
+    const args = await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are persona BETA.",
+      mockSessionId,
+    });
+    expect(args).toContain("--resume");
+    const resumeIdx = args.indexOf("--resume");
+    expect(args[resumeIdx + 1]).toBe(mockSessionId);
+    expect(args).toContain("--system-prompt");
+    const spIdx = args.indexOf("--system-prompt");
+    expect(args[spIdx + 1]).toBe("You are persona BETA.");
+  });
+
+  it("re-injects an updated system prompt on resume (identity drift recovery)", async () => {
+    const sessionKey = `sp-drift-${Date.now()}-${Math.random()}`;
+    const mockSessionId = `mock-sid-drift-${Date.now()}`;
+
+    await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are agent A (original).",
+      mockSessionId,
+    });
+
+    const args = await captureSubprocessArgs({
+      sessionKey,
+      systemPrompt: "You are agent A (corrected).",
+      mockSessionId,
+    });
+    expect(args).toContain("--resume");
+    const spIdx = args.indexOf("--system-prompt");
+    expect(spIdx).toBeGreaterThanOrEqual(0);
+    expect(args[spIdx + 1]).toBe("You are agent A (corrected).");
+  });
+
+  it("omits --system-prompt entirely when no system prompt is provided", async () => {
+    const args = await captureSubprocessArgs({
+      sessionKey: `sp-empty-${Date.now()}-${Math.random()}`,
+      systemPrompt: "",
+    });
+    expect(args).not.toContain("--system-prompt");
+  });
+});

--- a/src/__tests__/integration/stream.test.ts
+++ b/src/__tests__/integration/stream.test.ts
@@ -336,3 +336,79 @@ describe("concurrency", () => {
     }
   });
 });
+
+/**
+ * Run a stream against the env-echo scenario and return the parsed env snapshot
+ * the subprocess saw. Requires MCP loopback env vars to be set on process.env
+ * so stream.ts wires up OPENCLAW_MCP_AGENT_ID/SESSION_KEY/TOKEN at all.
+ */
+async function captureSubprocessEnv(opts: {
+  agentId?: string;
+  sessionKey?: string;
+}): Promise<Record<string, string | null>> {
+  const origScenario = process.env.MOCK_SCENARIO;
+  const origPort = process.env.__GLUECLAW_MCP_PORT;
+  const origToken = process.env.__GLUECLAW_MCP_TOKEN;
+  process.env.MOCK_SCENARIO = "env-echo";
+  process.env.__GLUECLAW_MCP_PORT = "12345";
+  process.env.__GLUECLAW_MCP_TOKEN = "test-token";
+
+  try {
+    const streamFn = createClaudeCliStreamFn({
+      claudeBin: MOCK_CLI,
+      sessionKey: opts.sessionKey ?? `env-${Date.now()}-${Math.random()}`,
+      agentId: opts.agentId,
+      modelOverride: "claude-sonnet-4-6",
+    });
+    const model = {
+      id: "glueclaw-sonnet",
+      api: "anthropic-messages",
+      provider: "glueclaw",
+    } as any;
+    const context = {
+      systemPrompt: "",
+      messages: [{ role: "user" as const, content: "say pong" }],
+    } as any;
+    const stream = await streamFn(model, context, {});
+    let resultText = "";
+    for await (const event of stream) {
+      if ((event as any).type === "done") {
+        resultText = (event as any).message.content[0].text;
+      }
+    }
+    return JSON.parse(resultText);
+  } finally {
+    if (origScenario !== undefined) process.env.MOCK_SCENARIO = origScenario;
+    else delete process.env.MOCK_SCENARIO;
+    if (origPort !== undefined) process.env.__GLUECLAW_MCP_PORT = origPort;
+    else delete process.env.__GLUECLAW_MCP_PORT;
+    if (origToken !== undefined) process.env.__GLUECLAW_MCP_TOKEN = origToken;
+    else delete process.env.__GLUECLAW_MCP_TOKEN;
+  }
+}
+
+describe("MCP agent identity", () => {
+  it("propagates opts.agentId to OPENCLAW_MCP_AGENT_ID", async () => {
+    const env = await captureSubprocessEnv({ agentId: "evacastro" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+  });
+
+  it("uses a different agentId for a different agent", async () => {
+    const env = await captureSubprocessEnv({ agentId: "roy" });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("roy");
+  });
+
+  it("falls back to 'main' when opts.agentId is omitted", async () => {
+    const env = await captureSubprocessEnv({});
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("main");
+  });
+
+  it("propagates opts.sessionKey alongside agentId independently", async () => {
+    const env = await captureSubprocessEnv({
+      agentId: "evacastro",
+      sessionKey: "session-xyz",
+    });
+    expect(env.OPENCLAW_MCP_AGENT_ID).toBe("evacastro");
+    expect(env.OPENCLAW_MCP_SESSION_KEY).toBe("session-xyz");
+  });
+});

--- a/src/__tests__/unit/pure-functions.test.ts
+++ b/src/__tests__/unit/pure-functions.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../stream.js";
 import { MODEL_CATALOG } from "../../catalog.js";
 import { binarySearchTrigger } from "../../healthcheck.js";
+import { resolveSessionKey } from "../../session-key.js";
 
 describe("buildUsage", () => {
   it("returns zeroed usage when called with undefined", () => {
@@ -356,5 +357,71 @@ describe("binarySearchTrigger", () => {
     const testFn = async (chunk: string) => !chunk.includes("TRIGGER");
     const result = await binarySearchTrigger(lines, testFn);
     expect(result).toBe("TRIGGER");
+  });
+});
+
+describe("resolveSessionKey", () => {
+  it("prefers sessionKey over everything else", () => {
+    expect(
+      resolveSessionKey({
+        sessionKey: "telegram:dm:+34xxx",
+        sessionId: "abc-uuid",
+        agentDir: "/home/x/.openclaw/agents/eva",
+      }),
+    ).toBe("telegram:dm:+34xxx");
+  });
+
+  it("falls back to sessionId when sessionKey is absent", () => {
+    expect(
+      resolveSessionKey({
+        sessionId: "conv-uuid-1",
+        agentDir: "/home/x/.openclaw/agents/eva",
+      }),
+    ).toBe("conv-uuid-1");
+  });
+
+  it("falls back to agentDir when sessionKey and sessionId are absent", () => {
+    expect(
+      resolveSessionKey({
+        agentDir: "/home/x/.openclaw/agents/eva",
+      }),
+    ).toBe("/home/x/.openclaw/agents/eva");
+  });
+
+  it("falls back to 'default' when nothing is provided", () => {
+    expect(resolveSessionKey({})).toBe("default");
+  });
+
+  it("yields distinct keys for two conversations of the same agent (the bug fix)", () => {
+    const agentDir = "/home/x/.openclaw/agents/eva";
+    const a = resolveSessionKey({
+      sessionKey: "telegram:dm:userA",
+      agentDir,
+    });
+    const b = resolveSessionKey({
+      sessionKey: "telegram:dm:userB",
+      agentDir,
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("yields the same key across turns of one conversation (resumption stability)", () => {
+    const ctx = {
+      sessionKey: "telegram:group:abc:user:def",
+      sessionId: "rotating-uuid-on-reset",
+      agentDir: "/home/x/.openclaw/agents/eva",
+    };
+    expect(resolveSessionKey(ctx)).toBe(resolveSessionKey(ctx));
+  });
+
+  it("treats empty string as a valid value (does not skip to fallback)", () => {
+    // Empty strings are unlikely in practice but we should not silently
+    // collapse them — only undefined triggers fallback.
+    expect(
+      resolveSessionKey({
+        sessionKey: "",
+        sessionId: "would-be-skipped",
+      }),
+    ).toBe("would-be-skipped");
   });
 });

--- a/src/session-key.ts
+++ b/src/session-key.ts
@@ -1,0 +1,27 @@
+/**
+ * Pick the most specific identity-bearing key OpenClaw exposed for this
+ * conversation, so each conversation gets its own Claude CLI session.
+ *
+ * Precedence:
+ *   1. `sessionKey` — semantic, stable across session resets for the same
+ *      logical conversation (channel/group/sender-encoded). Best.
+ *   2. `sessionId` — UUID of the current `<uuid>.jsonl` file. Rotates on reset.
+ *   3. `agentDir` — collapses all conversations of one agent into one bucket.
+ *      Used only when OpenClaw is older than openclaw/openclaw#73488 and
+ *      doesn't propagate session identity to provider plugins.
+ *   4. `"default"` — final safety net; should never hit in practice.
+ */
+export function resolveSessionKey(ctx: {
+  sessionKey?: string;
+  sessionId?: string;
+  agentDir?: string;
+}): string {
+  const pick = (...candidates: Array<string | undefined>) => {
+    for (const c of candidates) {
+      const trimmed = c?.trim();
+      if (trimmed) return trimmed;
+    }
+    return undefined;
+  };
+  return pick(ctx.sessionKey, ctx.sessionId, ctx.agentDir) ?? "default";
+}

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -91,12 +91,71 @@ export function buildMsg(
   };
 }
 
-/** Get the MCP loopback port and token from process.env.
- *  The gateway patches write these during MCP server startup. */
-export function getMcpLoopback(): { port: number; token: string } | undefined {
-  const port = process.env.__GLUECLAW_MCP_PORT;
-  const token = process.env.__GLUECLAW_MCP_TOKEN;
-  if (port && token) return { port: parseInt(port, 10), token };
+interface McpLoopbackRuntime {
+  port: number;
+  ownerToken: string;
+  nonOwnerToken?: string;
+}
+
+let _mcpLoopback: { port: number; token: string } | undefined;
+let _mcpBootstrapAttempted = false;
+
+/** Bootstrap OpenClaw's MCP loopback server in-process and return the
+ *  port + owner token. GlueClaw runs inside the gateway process, so we
+ *  share OpenClaw's module cache: importing the same `mcp-http-*.js`
+ *  the gateway loaded gives us the singleton, and a no-op when another
+ *  caller already started it.
+ *
+ *  Returns undefined if the OpenClaw dist cannot be located or its API
+ *  has changed — in that case the claude subprocess simply runs without
+ *  session tools, matching pre-RFC-001 behavior. */
+export async function getMcpLoopback(): Promise<
+  { port: number; token: string } | undefined
+> {
+  if (_mcpLoopback) return _mcpLoopback;
+  if (_mcpBootstrapAttempted) return undefined;
+  _mcpBootstrapAttempted = true;
+
+  try {
+    const { readdir } = await import("node:fs/promises");
+    const nodePaths = (process.env.NODE_PATH ?? "").split(":");
+    const distDirs = nodePaths
+      .filter((p) => p.includes("openclaw"))
+      .map((p) => p.replace(/\/node_modules\/?$/, "/dist"));
+
+    for (const distDir of distDirs) {
+      try {
+        const files = await readdir(distDir);
+        const mcpFile = files.find(
+          (f) => f.startsWith("mcp-http-") && f.endsWith(".js"),
+        );
+        if (!mcpFile) continue;
+        const mod = (await import(
+          `file://${distDir}/${mcpFile}`
+        )) as Record<string, unknown>;
+        // Minified aliases: n=ensureMcpLoopbackServer, i=getActiveMcpLoopbackRuntime
+        const ensureFn = (mod["n"] ?? mod["ensureMcpLoopbackServer"]) as
+          | (() => Promise<unknown>)
+          | undefined;
+        const getRuntime = (mod["i"] ?? mod["getActiveMcpLoopbackRuntime"]) as
+          | (() => McpLoopbackRuntime | undefined)
+          | undefined;
+        if (typeof ensureFn !== "function" || typeof getRuntime !== "function") {
+          continue;
+        }
+        await ensureFn();
+        const runtime = getRuntime();
+        if (runtime?.port && runtime.ownerToken) {
+          _mcpLoopback = { port: runtime.port, token: runtime.ownerToken };
+          return _mcpLoopback;
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    // Non-fatal: session tools simply won't be available
+  }
   return undefined;
 }
 
@@ -230,7 +289,7 @@ export function createClaudeCliStreamFn(opts: {
         delete env.ANTHROPIC_API_KEY_OLD;
 
         // Wire up MCP bridge for OpenClaw gateway tools
-        const loopback = getMcpLoopback();
+        const loopback = await getMcpLoopback();
         if (loopback) {
           const mcp = writeMcpConfig(loopback.port);
           mcpCleanup = mcp.cleanup;

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -195,14 +195,17 @@ export function createClaudeCliStreamFn(opts: {
           "--verbose",
           "--include-partial-messages",
         ];
-        // Resume session for multi-turn conversation memory
+        // Resume session for multi-turn conversation memory.
+        // Always re-inject the system prompt — on resumptions the CLI would
+        // otherwise stick to whatever identity was used on the first turn,
+        // leaving no way for callers to reinforce or correct an agent's
+        // identity across turns.
         const sessionKey = `glueclaw:${opts.sessionKey ?? "default"}`;
         const existingSessionId = sessionMap.get(sessionKey);
         if (existingSessionId) {
           args.push("--resume", existingSessionId);
-        } else {
-          if (cleanPrompt) args.push("--system-prompt", cleanPrompt);
         }
+        if (cleanPrompt) args.push("--system-prompt", cleanPrompt);
         if (resolvedModel) args.push("--model", resolvedModel);
 
         // Debug: log args for resume troubleshooting

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -170,6 +170,7 @@ function evictSessions(): void {
 export function createClaudeCliStreamFn(opts: {
   claudeBin?: string;
   sessionKey?: string;
+  agentId?: string;
   modelOverride?: string;
   requestTimeoutMs?: number;
 }): StreamFn {
@@ -233,7 +234,7 @@ export function createClaudeCliStreamFn(opts: {
           args.push("--strict-mcp-config", "--mcp-config", mcp.path);
           env.OPENCLAW_MCP_TOKEN = loopback.token;
           env.OPENCLAW_MCP_SESSION_KEY = opts.sessionKey ?? "";
-          env.OPENCLAW_MCP_AGENT_ID = "main";
+          env.OPENCLAW_MCP_AGENT_ID = opts.agentId ?? "main";
           env.OPENCLAW_MCP_ACCOUNT_ID = "";
           env.OPENCLAW_MCP_MESSAGE_CHANNEL = "";
         }


### PR DESCRIPTION
Fixes #30.

## Summary

GlueClaw registers as a provider, so OpenClaw's prepare runtime never calls `ensureMcpLoopbackServer()` for our sessions. The Claude subprocess was being spawned without `--mcp-config`, leaving `sessions_send` (and other session tools) advertised in the system prompt but never injected as real `tool_use` calls. Callers fell back to external WebSocket RPC, which bypasses the inter-agent `extraSystemPrompt` stamping.

This PR fixes it from the provider itself, in-process — no patches to OpenClaw's dist.

## What changes

- **`src/stream.ts`** — `getMcpLoopback()` is now async and bootstraps the MCP loopback in-process:
  1. Locate OpenClaw's `dist/` via `process.env.NODE_PATH` (the gateway sets it to `<install-root>/node_modules:...`).
  2. Import `mcp-http-*.js` via a `file://` URL — same module cache key the gateway uses, so we share the singleton.
  3. Call `ensureMcpLoopbackServer()` (idempotent) and read `{ port, ownerToken }` via `getActiveMcpLoopbackRuntime()` directly out of memory.
  4. Result is cached for subsequent invocations.

- **`install.sh`** — removes the old `sed`-patch step against OpenClaw's `mcp-http-*.js`. That patch:
  - Was attempting to leak `port`/`token` through `process.env`, unnecessary now that GlueClaw runs in-process.
  - Had a latent `ReferenceError: token is not defined` on OpenClaw 2026.4.24, where the bundle exposes `ownerToken`/`nonOwnerToken` instead of a bare `token` in that scope. The bug never surfaced before because GlueClaw never reached the loopback codepath.
  - Required `sed` against minified bundle internals — fragile across upstream updates.

  Steps renumbered 7 → 6. \`install.sh\` now touches no files outside the GlueClaw repo.

- **`docs/RFC-001-sessions-send-native.md`** — full design notes.

- **`package-lock.json`** — incidental bump of engines constraint to match \`package.json\` (>=22.0.0), refreshed by \`npm install\`.

## Out of scope (follow-up)

End-to-end inter-agent authentication (the gateway stamping the receiver's \`extraSystemPrompt\` with \`Agent 1 (requester) session: agent:<id>:...\`) was the long-term motivation behind this RFC, but it depends on gateway-side identification logic that goes beyond exposing the MCP tool natively. Initial verification with a real agent-to-agent message showed that \`sessions_send\` is now invocable as a native tool, but the receiver did not see the requester-session block. A follow-up issue will track that work — likely candidates are the empty \`OPENCLAW_MCP_ACCOUNT_ID\` / \`OPENCLAW_MCP_MESSAGE_CHANNEL\` headers and the routing logic in OpenClaw's MCP loopback handler.

## Test plan

- [x] \`bash install.sh\` runs cleanly; no patching of OpenClaw dist.
- [x] After gateway restart, spawned \`claude\` subprocess argv contains \`--strict-mcp-config\` + \`--mcp-config /tmp/glueclaw-mcp-*/mcp.json\`.
- [x] No errors in gateway journal.
- [ ] (Follow-up scope) End-to-end inter-agent auth stamping.